### PR TITLE
Return error from GitHub API

### DIFF
--- a/dependency-hunter.js
+++ b/dependency-hunter.js
@@ -73,6 +73,8 @@ var update = function(organization) {
 			}, function(err, res) {
 				// File is not there
 				if (err && err.code === 404) return callback(null, {});
+				// Error from github API
+				if (err) return callback(err);
 
 				var json;
 				try {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "after-all": "^2.0.2",
     "ghauth": "^3.0.0",
-    "github": "^3.1.1",
+    "github": "9.0.0",
     "single-line-log": "^1.0.0",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Today dependency-hunter failed to parse JSON response from GitHub API and I didn't know why. 
What I got in console
```
Error: TypeError: Cannot read property 'data' of undefinedCould not parse body for debitoor-api-docs
```

With this change I can see this error:
```
message: '{\n  "documentation_url": "https://developer.github.com/v3/#abuse-rate-limits",\n  "message": "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."\n}\n',
```

How to solve this error - it's another question, but at least right now we can see the error